### PR TITLE
Updated CommSpace usage + CMake cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+build/
+
+**/.vscode/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,16 +36,3 @@ if(CLANG_FORMAT_FOUND)
     COMMAND ${CLANG_FORMAT_EXECUTABLE} -i -style=file ${FORMAT_SOURCES}
     DEPENDS ${FORMAT_SOURCES})
 endif()
-
-# Find MPI ADVANCE Stream Triggering
-option(CabanaGhost_ENABLE_MPI_ADVANCE "Support MPI Advance backends, namely stream-triggering." OFF)
-#Cabana_add_dependency( PACKAGE stream-triggering )
-#set_package_properties(stream-triggering PROPERTIES TYPE OPTIONAL PURPOSE "Stream Triggered Backend")
-if( CabanaGhost_ENABLE_MPI_ADVANCE )
-  find_package(stream-triggering REQUIRED)
-  if(stream-triggering_FOUND)# AND Cabana_ENABLE_MPISTREAM)
-  install(FILES
-    ${CMAKE_CURRENT_SOURCE_DIR}/cmake/Findstream-triggering.cmake
-    DESTINATION ${CMAKE_INSTALL_PREFIX} )
-  endif()
-endif()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -5,7 +5,7 @@ set(DEPENDS_ON
   MPI::MPI_CXX
   )
 
-if( stream-triggering_FOUND )
+if( Cabana_ENABLE_MPI_ADVANCE )
   list(APPEND DEPENDS_ON
     stream-triggering
   )

--- a/src/GOL.cpp
+++ b/src/GOL.cpp
@@ -286,7 +286,7 @@ int main( int argc, char* argv[] )
             createHaloSolver<Kokkos::DefaultExecutionSpace, 2, Approach::Flat, 
                 Approach::Stream>(cl.global_num_cells, true, cl.comm_space, gol2Dfunctor, initializer );
         t1 = timer.seconds();
-        solver.solve(cl.t_final, 0.0, cl.write_freq);
+        solver->solve(cl.t_final, 0.0, cl.write_freq);
         t2 = timer.seconds();
     }
     if ( rank == 0 )

--- a/src/ProblemManager.hpp
+++ b/src/ProblemManager.hpp
@@ -115,7 +115,7 @@ class ProblemManager
         // First we create the generic halo pattern itself which can
         // handle non-persistent halos 
         int halo_depth = _local_grid->haloCellWidth();
-        _halo = Cabana::Grid::Experimental::createStreamHalo( exec_space(), 
+        _halo = Cabana::Grid::Experimental::createStreamHalo<comm_space>( exec_space(), 
             Cabana::Grid::NodeHaloPattern<Dims>(), halo_depth, 
             *_liveness_curr );
 

--- a/src/Solver.hpp
+++ b/src/Solver.hpp
@@ -352,7 +352,7 @@ createHaloSolver( std::array<int, Dims> global_num_cells, bool periodic,
     } else if (comm_backend.compare("mpi-advance") == 0) {
 #ifdef Cabana_ENABLE_MPI_ADVANCE
         return std::make_shared<
-            Solver<ExecutionSpace, Cabana::CommSpace::MpiAdvance,  IterationFunc,
+            Solver<ExecutionSpace, Cabana::CommSpace::MpiAdvance, Dims, IterationFunc,
 		CompApproach, CommApproach>>(
                     global_num_cells, periodic, halo, initializer);
 #else


### PR DESCRIPTION
- Added .gitignore to ignore VSCode stuff
- Fixed two bugs (missing template parameter on Solver class; use of "." over "->" in GOL
- Updated `createStreamHalo` call to pass along `CommSpace` parameter
- Removed unnecessary CMake code -- Cabana already provides the CMake stuff for getting `stream-triggering`, just need to link with it.

After today, I will merge this branch and delete the "solver time" branch 